### PR TITLE
🔧 Properly resolve file paths before checking availability.

### DIFF
--- a/lib/plumber.js
+++ b/lib/plumber.js
@@ -1,5 +1,6 @@
 const daemon = require('daemon');
 const fs = require('fs');
+const path = require('path');
 var os_eol = require('os').EOL;
 
 console.log("=======================================================");
@@ -19,8 +20,8 @@ if (args[2].toLowerCase() !== 'connect') {
 }
 
 // see if both ends of the pipe can be connected
-var opening = process.argv[3];
-var tailEnd = process.argv[4];
+var opening = path.resolve(process.cwd(), process.argv[3]);
+var tailEnd = path.resolve(process.cwd(), process.argv[4]);
 
 if (!fs.existsSync(opening)) {
     console.log('Source file does not exist! Exiting...');


### PR DESCRIPTION
Used `path.resolve()` to resolve file paths before attempting to do anything with them.